### PR TITLE
Always use setPrefLocal to set a preference, TS.model.prefs doesn't e…

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -11,11 +11,7 @@ document.body.appendChild(function(){
         }
 
         TS.utility.contenteditable.isCursorInPreBlock = function() {
-            if (TS.model.prefs) {
-                TS.model.prefs.enter_is_special_in_tbt = true
-            } else {
-                TS.prefs.setPref('enter_is_special_in_tbt', true)
-            }
+            TS.prefs.setPrefLocal('enter_is_special_in_tbt', true)
             return isEnabled()
         }
     };


### PR DESCRIPTION
…xist and neither does TS.prefs.setPref

I noticed that `TS.prefs.setPref` is spitting out a deprecation warning `TS.prefs.setPref has been deprecated! Please do not use this function. Use TS.prefs.setPrefLocal instead.`, and `TS.model.prefs` doesn't appear to exist anymore. This seems to work instead!